### PR TITLE
Add MIT license to studio interfaces and dependencies (#5)

### DIFF
--- a/core/dsp/src/accumulator.rs
+++ b/core/dsp/src/accumulator.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 /// An accumulator that compensates for floating-point loss of precision
 ///

--- a/core/dsp/src/conversion.rs
+++ b/core/dsp/src/conversion.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 /// Convert a value in decibels to its corresponding linear amplitude value
 #[inline(always)]

--- a/core/dsp/src/delay.rs
+++ b/core/dsp/src/delay.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #![allow(missing_docs)]
 

--- a/core/dsp/src/envelope_follower.rs
+++ b/core/dsp/src/envelope_follower.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use crate::WindowedMovingRms;
 use crate::flush_f32_to_zero;

--- a/core/dsp/src/float.rs
+++ b/core/dsp/src/float.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 /// Flush tiny f32s to zero to avoid denormalized numbers
 ///

--- a/core/dsp/src/interpolation.rs
+++ b/core/dsp/src/interpolation.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 /// Linearly interpolate between two values
 #[inline(always)]

--- a/core/dsp/src/lib.rs
+++ b/core/dsp/src/lib.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 //! # haptic_dsp
 //!

--- a/core/dsp/src/linspace.rs
+++ b/core/dsp/src/linspace.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 /// An iterator providing evenly spaced values over a range
 ///

--- a/core/dsp/src/rms.rs
+++ b/core/dsp/src/rms.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use crate::Accumulator;
 use crate::FixedDelayLine;

--- a/core/dsp/src/spectral.rs
+++ b/core/dsp/src/spectral.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 mod features;
 mod spectral_analyzer;

--- a/core/dsp/src/spectral/features.rs
+++ b/core/dsp/src/spectral/features.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use crate::Complex;
 use crate::linspace;

--- a/core/dsp/src/spectral/spectral_analyzer.rs
+++ b/core/dsp/src/spectral/spectral_analyzer.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::sync::Arc;
 

--- a/core/dsp/src/spectral/windows.rs
+++ b/core/dsp/src/spectral/windows.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::f32::consts::PI;
 

--- a/core/dsp/src/test_utils.rs
+++ b/core/dsp/src/test_utils.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 //! Utilities that are useful when testing DSP logic
 

--- a/core/haptic_data/src/ahap.rs
+++ b/core/haptic_data/src/ahap.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 //! Support for the AHAP file format, including conversion from [HapticData]
 

--- a/core/haptic_data/src/breakpoint.rs
+++ b/core/haptic_data/src/breakpoint.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 /// A trait for breakpoints, allowing time/value structs to maintain their own representations
 pub trait Breakpoint: Clone {

--- a/core/haptic_data/src/json.rs
+++ b/core/haptic_data/src/json.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use thiserror::Error;
 

--- a/core/haptic_data/src/lib.rs
+++ b/core/haptic_data/src/lib.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 //! The home of the HapticsSDK data format
 

--- a/core/haptic_data/src/parametric.rs
+++ b/core/haptic_data/src/parametric.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::time::Duration;
 

--- a/core/haptic_data/src/test_utils.rs
+++ b/core/haptic_data/src/test_utils.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 //! Utilities for writing tests that need haptic data
 

--- a/core/haptic_data/src/v1.rs
+++ b/core/haptic_data/src/v1.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::cmp::Ordering;
 use std::ops::RangeInclusive;

--- a/core/haptic_data/src/version.rs
+++ b/core/haptic_data/src/version.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::fmt;
 

--- a/core/renderer/build.rs
+++ b/core/renderer/build.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::env;
 use std::fs;

--- a/core/renderer/src/acf.rs
+++ b/core/renderer/src/acf.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/core/renderer/src/android_constant_intensity.rs
+++ b/core/renderer/src/android_constant_intensity.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::time::Duration;
 

--- a/core/renderer/src/android_waveform.rs
+++ b/core/renderer/src/android_waveform.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::cmp::max;
 use std::cmp::min;

--- a/core/renderer/src/continuous_oscillator_settings.rs
+++ b/core/renderer/src/continuous_oscillator_settings.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/core/renderer/src/emphasis_oscillator_settings.rs
+++ b/core/renderer/src/emphasis_oscillator_settings.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/core/renderer/src/error.rs
+++ b/core/renderer/src/error.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use thiserror::Error;
 

--- a/core/renderer/src/haptic_file_renderer.rs
+++ b/core/renderer/src/haptic_file_renderer.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::io;
 use std::marker::PhantomData;

--- a/core/renderer/src/lib.rs
+++ b/core/renderer/src/lib.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 //! # haptic_renderer
 //!

--- a/core/renderer/src/render_settings.rs
+++ b/core/renderer/src/render_settings.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/core/renderer/src/renderer_c.rs
+++ b/core/renderer/src/renderer_c.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]

--- a/core/renderer/src/streaming_event.rs
+++ b/core/renderer/src/streaming_event.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use haptic_data::BasicBreakpoint;
 use haptic_data::Breakpoint;

--- a/core/renderer/src/streaming_event_reader.rs
+++ b/core/renderer/src/streaming_event_reader.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::ops::Deref;
 

--- a/core/renderer/src/streaming_renderer.rs
+++ b/core/renderer/src/streaming_renderer.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::mem::MaybeUninit;
 

--- a/core/renderer/src/test_utils.rs
+++ b/core/renderer/src/test_utils.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 //! Utilities for working with streaming events in tests
 

--- a/interfaces/studio/audio_analysis/src/amplitude_analyzer.rs
+++ b/interfaces/studio/audio_analysis/src/amplitude_analyzer.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use haptic_dsp::RmsEnvelopeFollower;
 use serde::Deserialize;

--- a/interfaces/studio/audio_analysis/src/audio_loading.rs
+++ b/interfaces/studio/audio_analysis/src/audio_loading.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::error::Error;
 use std::io::Cursor;

--- a/interfaces/studio/audio_analysis/src/audio_preprocessing.rs
+++ b/interfaces/studio/audio_analysis/src/audio_preprocessing.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use haptic_dsp::Accumulator;
 use haptic_dsp::db_to_amplitude;

--- a/interfaces/studio/audio_analysis/src/breakpoint_reduction.rs
+++ b/interfaces/studio/audio_analysis/src/breakpoint_reduction.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 //! # Breakpoint Reduction
 //!

--- a/interfaces/studio/audio_analysis/src/emphasis_detection.rs
+++ b/interfaces/studio/audio_analysis/src/emphasis_detection.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 //! # Emphasis detection
 //!

--- a/interfaces/studio/audio_analysis/src/frequency_analyzer.rs
+++ b/interfaces/studio/audio_analysis/src/frequency_analyzer.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/interfaces/studio/audio_analysis/src/lib.rs
+++ b/interfaces/studio/audio_analysis/src/lib.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 //! # haptic_audio_analysis
 //!

--- a/interfaces/studio/audio_analysis/src/offline_analysis.rs
+++ b/interfaces/studio/audio_analysis/src/offline_analysis.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::error::Error;
 

--- a/interfaces/studio/audio_analysis/src/spectrum_analysis.rs
+++ b/interfaces/studio/audio_analysis/src/spectrum_analysis.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 //! # Spectrum analysis
 //!

--- a/interfaces/studio/audio_analysis/src/visual_waveform.rs
+++ b/interfaces/studio/audio_analysis/src/visual_waveform.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/interfaces/studio/napi/build.rs
+++ b/interfaces/studio/napi/build.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 extern crate napi_build;
 

--- a/interfaces/studio/napi/src/audio_analysis.rs
+++ b/interfaces/studio/napi/src/audio_analysis.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use haptic_audio_analysis::OfflineAnalysisSettings;
 use haptic_audio_analysis::audio_to_haptics;

--- a/interfaces/studio/napi/src/audio_decoding.rs
+++ b/interfaces/studio/napi/src/audio_decoding.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use haptic_audio_analysis::MultiChannelBehavior;
 use haptic_audio_analysis::PreprocessingSettings;

--- a/interfaces/studio/napi/src/haptic_data.rs
+++ b/interfaces/studio/napi/src/haptic_data.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use haptic_data::HapticData;
 use haptic_data::ahap::Ahap;

--- a/interfaces/studio/napi/src/haptic_renderer.rs
+++ b/interfaces/studio/napi/src/haptic_renderer.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::io::Cursor;
 

--- a/interfaces/studio/napi/src/helpers.rs
+++ b/interfaces/studio/napi/src/helpers.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 use std::error::Error;
 

--- a/interfaces/studio/napi/src/lib.rs
+++ b/interfaces/studio/napi/src/lib.rs
@@ -1,4 +1,7 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 // The napi-derive proc macro generates code without doc comments when building with the
 // crates.io version. Allow missing_docs to accommodate this.


### PR DESCRIPTION
Summary:

Add MIT license to studio interfaces and dependencies

Reviewed By: mzzndr

Differential Revision: D101627717
